### PR TITLE
treewide: remove unused funding url

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "type": "git",
     "url": "git+https://github.com/the-mikedavis/tree-sitter-git-rebase.git"
   },
-  "funding": "",
   "license": "MIT",
   "author": {
     "name": "Michael Davis",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">=3.10"
 version = "0.1.0"
 
 [project.urls]
-Funding  = ""
 Homepage = "https://github.com/the-mikedavis/tree-sitter-git-rebase"
 
 [project.optional-dependencies]

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -25,8 +25,7 @@
       }
     ],
     "links": {
-      "repository": "https://github.com/the-mikedavis/tree-sitter-git-rebase",
-      "funding": ""
+      "repository": "https://github.com/the-mikedavis/tree-sitter-git-rebase"
     }
   },
   "bindings": {


### PR DESCRIPTION
## Motivation
We ran into some issues when trying to parse `tree-sitter.json` as it didn't validate with the scheme, due to the funding URL being empty. 

## Solution
The easiest way is to just remove it (for now). It can always be added back later, in case it is needed, but since it isn't used right now, I think it doesn't hurt removing it.